### PR TITLE
Split compose setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,56 @@
-# Variables
+# ========================================================
+# Fursave Project Makefile
+# ========================================================
+
+# ---------------- Global Variables ----------------------
 COMPOSE_BIN := docker compose
 PROJECT_NAME := fursave
 
-# Teardown
+# ---------------- Colors & Formatting -------------------
+GREEN  := \033[0;32m
+YELLOW := \033[0;33m
+RESET  := \033[0m
+
+# ========================================================
+# Project-wide Configuration
+# ========================================================
+.PHONY: help
+help:
+	@echo -e "${GREEN}Fursave Project Makefile${RESET}"
+	@echo -e "${YELLOW}Top-Level Targets:${RESET}"
+	@echo -e "  ${BLUE}make help${RESET}         - Show this help message"
+	@echo -e "  ${BLUE}make teardown-all${RESET} - Teardown all services"
+	@echo ""
+	@echo -e "${YELLOW}Go Library Service Targets:${RESET}"
+	@echo -e "  ${BLUE}make golib-setup${RESET}       - Setup Go library service"
+	@echo -e "  ${BLUE}make golib-teardown${RESET}    - Teardown Go library service"
+	@echo -e "  ${BLUE}make golib-test${RESET}        - Run tests for Go library service"
+	@echo ""
+	@echo -e "${YELLOW}Ledger Service Targets:${RESET}"
+	@echo -e "  ${BLUE}make ledgersvc-setup${RESET}         - Setup Ledger service and dependencies"
+	@echo -e "  ${BLUE}make ledgersvc-teardown${RESET}      - Teardown Ledger service"
+	@echo -e "  ${BLUE}make ledgersvc-test${RESET}          - Run tests for Ledger service"
+	@echo -e "  ${BLUE}make ledgersvc-pg${RESET}            - Start PostgreSQL service"
+	@echo -e "  ${BLUE}make ledgersvc-pg-migrate${RESET}    - Run database migrations"
+	@echo -e "  ${BLUE}make ledgersvc-pg-migrate-down${RESET} - Rollback database migrations"
+
+# ========================================================
+# Service-Specific Compose Configurations
+# ========================================================
+# Go Library Service
+COMPOSE_GOLIB := ${COMPOSE_BIN} -f src/golib/build/docker-compose.yaml -p ${PROJECT_NAME}-golib
+
+# Ledger Service
+COMPOSE_LEDGERSVC := ${COMPOSE_BIN} -f src/ledgersvc/build/docker-compose.yaml -p ${PROJECT_NAME}-ledgersvc
+
+# ========================================================
+# Top-Level Management Targets
+# ========================================================
 teardown-all: golib-teardown ledgersvc-teardown
 
-# Golib Service
-COMPOSE_GOLIB := ${COMPOSE_BIN} -f src/golib/build/docker-compose.yaml -p ${PROJECT_NAME}-golib
+# ========================================================
+# Go Library Service Targets
+# ========================================================
 golib-teardown: COMPOSE_CMD=${COMPOSE_GOLIB}
 golib-teardown: teardown
 
@@ -19,21 +63,27 @@ golib-setup: go-vendor
 golib-test: COMPOSE_CMD=${COMPOSE_GOLIB}
 golib-test: go-test
 
-# Ledgersvc Service
-COMPOSE_LEDGERSVC := ${COMPOSE_BIN} -f src/ledgersvc/build/docker-compose.yaml -p ${PROJECT_NAME}-ledgersvc
+# ========================================================
+# Ledger Service Targets
+# ========================================================
+# PostgreSQL-specific targets
+ledgersvc-pg:
+	${COMPOSE_LEDGERSVC} up -d pg
+
+ledgersvc-pg-migrate:
+	${COMPOSE_LEDGERSVC} run --rm pg-migrate sh -c 'sleep 5 && ./migrate -verbose -path /migrations -database $$PG_URL up'
+
+ledgersvc-pg-migrate-down:
+	${COMPOSE_LEDGERSVC} run --rm pg-migrate sh -c 'sleep 5 && ./migrate -verbose -path /migrations -database $$PG_URL down'
+
+ledgersvc-pg-migrate-redo: ledgersvc-pg-migrate-down ledgersvc-pg-migrate
+
+# Service-level targets
 ledgersvc-teardown: COMPOSE_CMD=${COMPOSE_LEDGERSVC}
 ledgersvc-teardown: teardown
 
 ledgersvc-clean-vendor: COMPOSE_CMD=${COMPOSE_LEDGERSVC}
 ledgersvc-clean-vendor: go-clean-vendor
-
-ledgersvc-pg:
-	${COMPOSE_LEDGERSVC} up -d pg
-ledgersvc-pg-migrate:
-	${COMPOSE_LEDGERSVC} run --rm pg-migrate sh -c 'sleep 5 && ./migrate -verbose -path /migrations -database $$PG_URL up'
-ledgersvc-pg-migrate-down:
-	${COMPOSE_LEDGERSVC} run --rm pg-migrate sh -c 'sleep 5 && ./migrate -verbose -path /migrations -database $$PG_URL down'
-ledgersvc-pg-migrate-redo: pg-migrate-down pg-migrate
 
 ledgersvc-setup: COMPOSE_CMD=${COMPOSE_LEDGERSVC}
 ledgersvc-setup: ledgersvc-pg ledgersvc-pg-migrate go-vendor go-gen
@@ -47,17 +97,30 @@ ledgersvc-build-binaries: go-build-binaries
 ledgersvc-serverd:
 	${COMPOSE_LEDGERSVC} run --rm --service-ports go sh -c 'go run cmd/serverd/*.go'
 
-# Reusable commands
+# ========================================================
+# Reusable Go Commands
+# ========================================================
 go-vendor:
 	${COMPOSE_CMD} run --rm go sh -c 'go mod vendor'
+
 go-clean-vendor:
 	${COMPOSE_CMD} run --rm go sh -c 'go mod tidy && go mod vendor'
+
 go-gen:
 	${COMPOSE_CMD} run --rm go sh -c 'go generate ./...'
+
 go-test:
 	${COMPOSE_CMD} run --rm go sh -c 'go test -coverprofile=coverage.out -failfast -timeout 5m ./...'
+
 go-build-binaries:
 	${COMPOSE_CMD} run --rm go sh -c 'for CMD in `ls cmd`; do (go build -v -o build/binaries/$$CMD ./cmd/$$CMD) done'
 
+# ========================================================
+# Cleanup Targets
+# ========================================================
 teardown:
 	${COMPOSE_CMD} down --rmi local
+
+# ========================================================
+# End of Makefile
+# ========================================================

--- a/src/golib/build/docker-compose.yaml
+++ b/src/golib/build/docker-compose.yaml
@@ -1,0 +1,15 @@
+services:
+  go:
+    image: golang:1.23-alpine
+    networks:
+      - net
+    env_file:
+      - path: ../.env
+    environment: # Overriding for running inside container
+      GOARCH: amd64
+      GOOS: linux
+    volumes:
+      - ../:/src/golib:delegated
+    working_dir: /src/golib
+networks:
+  net:

--- a/src/ledgersvc/build/docker-compose.yaml
+++ b/src/ledgersvc/build/docker-compose.yaml
@@ -1,18 +1,5 @@
 services:
-
-  golib-go:
-    image: golang:1.23-alpine
-    env_file:
-      - path: ../src/golib/.env
-    environment: # Overriding for running inside container
-      GOARCH: amd64
-      GOOS: linux
-    volumes:
-      - ../src/golib:/src:cached
-      - golib-build-cache:/root/.cache/go-build
-    working_dir: /src
-
-  ledgersvc-pg:
+  pg:
     image: postgres:17-alpine
     restart: always
     healthcheck:
@@ -28,47 +15,43 @@ services:
       POSTGRES_USER: pg
       POSTGRES_PASSWORD: trustmebro
       POSTGRES_DB: pg
-  ledgersvc-pg-migrate:
+  pg-migrate:
     image: migrate/migrate:v4.18.1
     entrypoint: "" # Overriding in order to write command in Makefile
     networks:
       - net
     environment:
-      PG_URL: postgres://@ledgersvc-pg:5432/pg?sslmode=disable
+      PG_URL: postgres://@pg:5432/pg?sslmode=disable
       PGUSER: pg
       PGPASSWORD: trustmebro
     volumes:
-      - ../src/ledgersvc/db-scripts/pg/migrations:/migrations
+      - ../db-scripts/pg/migrations:/migrations
     depends_on:
-      ledgersvc-pg:
+      pg:
         condition: service_healthy
         restart: true
-  ledgersvc-go:
+  go:
     build:
       context: .
-      dockerfile: ./go-local.Dockerfile
+      dockerfile: ../../../build/go-local.Dockerfile
     networks:
       - net
     ports:
-      - "4000:4000"
+      - "3000:4000"
     env_file:
-      - path: ../src/ledgersvc/.env
+      - path: ../.env
     environment: # Overriding for running inside container
       GOARCH: amd64
       GOOS: linux
-      PSQL_HOST: ledgersvc-pg
+      PSQL_HOST: pg
     volumes:
-      - ../src/ledgersvc:/src:cached
-      - ../src/golib:/golib:cached
-      - ledgersvc-build-cache:/root/.cache/go-build
-    working_dir: /src
+      - ../../golib:/src/golib:delegated
+      - ../:/src/ledgersvc:delegated
+    working_dir: /src/ledgersvc
     depends_on:
-      ledgersvc-pg:
+      pg:
         condition: service_healthy
         restart: true
 
 networks:
   net:
-volumes:
-  golib-build-cache:
-  ledgersvc-build-cache:


### PR DESCRIPTION
Refactoring the setup to use docker compose primarily for:-
- Go module management
- Mock generation & other dynamic code generation
- Running unit tests & integration tests (internal to the service)

But not intending to use Docker Compose for running the application on the local machine and instead use one of the local k8s dev envs such as Skaffold/Tilt/DevSpace to do so.

So splitting the docker compose to per service for better isolation

Also taking the chance to improve the readability of the Makefile.