### PR TITLE
Add integration with golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Print inputs context
         run: echo "${{ toJSON(inputs) }}"
 
-  ####### Run tests & build Start ######
+  ####### Run linters, tests & build: START ######
   test-and-build:
     name: Test & Build (${{ matrix.project }})
     needs: [ init ]
@@ -45,6 +45,12 @@ jobs:
         run: make ${{ matrix.project }}-setup
       - name: Run tests
         run: make ${{ matrix.project }}-test
+      - name: Run golangci-lint
+        if: ${{ matrix.language == 'go' }}
+        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 #v6.1.1
+        with:
+          version: v1.63
+          working-directory: src/${{ matrix.project }}/
       - name: Build binaries
         if: ${{ matrix.type == 'application' && matrix.language == 'go' }}
         run: make ${{ matrix.project }}-build-binaries
@@ -69,7 +75,7 @@ jobs:
           registry-password: ${{ secrets.GITHUB_TOKEN }}
           image-prefix: ${{ github.repository }}
           push: ${{ github.event_name != 'pull_request' }}
-  ####### Run tests & build End ######
+  ####### Run linters, tests & build: END ######
 
   ####### SAST Start ######
   sonar-scan-root:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,96 @@
+run:
+  modules-download-mode: "vendor"
+  allow-parallel-runners: true
+output:
+  show-stats: true
+linters:
+  disable-all: true
+  enable:
+    # Recommended:-
+    - gofumpt
+    - gosec
+    - govet
+    - revive
+    - staticcheck
+    - stylecheck
+    - unused
+    - gosimple
+    - errcheck
+    - ineffassign
+    # Personal:-
+    - bodyclose
+    - copyloopvar
+    - dupl
+    - errname
+    - exptostd
+    - exhaustive
+    - gci
+    - godot
+    - gocritic
+    - gocheckcompilerdirectives
+    - gochecknoinits
+    - misspell
+    - noctx
+    - perfsprint
+    - tenv
+    - testifylint
+    - unconvert
+    - usestdlibvars
+    - wrapcheck
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gocritic
+        - gosec
+  # fix: true
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+  gofumpt:
+    extra-rules: true
+  revive:
+    enable-all-rules: true
+    rules:
+      - name: indent-error-flow
+        disabled: true
+      - name: imports-blocklist
+        arguments:
+          - "lib/pq"
+          - "github.com/ericlagergren/decimal"
+      - name: line-length-limit
+        arguments: [160]
+        exclude: ["TEST"]
+      - name: flag-parameter
+        disabled: true
+      - name: bare-return
+        disabled: true
+      - name: add-constant
+        disabled: true
+      - name: function-length
+        exclude: ["TEST"]
+      - name: cognitive-complexity
+        exclude: ["TEST"]
+  exhaustive:
+    default-signifies-exhaustive: true
+  godot:
+    scope: all
+    exclude:
+      - "^// TODO:"
+      - "^# TODO:"
+  testifylint:
+    enable-all: true
+  usestdlibvars:
+    time-month: true
+    time-layout: true
+    crypto-hash: true
+    sql-isolation-level: true
+    tls-signature-scheme: true
+    constant-kind: true
+  wrapcheck:
+    ignorePackageGlobs:
+      - github.com/kneadCODE/fursave/src/golib/*

--- a/src/golib/.golangci.yaml
+++ b/src/golib/.golangci.yaml
@@ -1,0 +1,1 @@
+../../.golangci.yaml

--- a/src/golib/config/app.go
+++ b/src/golib/config/app.go
@@ -8,7 +8,7 @@ import (
 
 // App represents the application configuration.
 type App struct {
-	// Env is the environment in which the application is running
+	// Env is the environment in which the application is running.
 	Env Environment
 	Res *resource.Resource
 }

--- a/src/golib/config/context.go
+++ b/src/golib/config/context.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kneadCODE/fursave/src/golib/internal/basic"
 )
 
-// AppFromContext retrieves the App from context if exists else return a new App
+// AppFromContext retrieves the App from context if exists else return a new App.
 func AppFromContext(ctx context.Context) App {
 	if v, ok := ctx.Value(appCtxKey).(App); ok {
 		return v
@@ -14,7 +14,7 @@ func AppFromContext(ctx context.Context) App {
 	return App{}
 }
 
-// SetAppInContext sets App in the given context
+// SetAppInContext sets App in the given context.
 func SetAppInContext(ctx context.Context, cfg App) context.Context {
 	return context.WithValue(ctx, appCtxKey, cfg)
 }

--- a/src/golib/config/context_test.go
+++ b/src/golib/config/context_test.go
@@ -8,40 +8,40 @@ import (
 )
 
 func TestAppFromContext(t *testing.T) {
-	// Given:
+	// Given:.
 	ctx := context.Background()
 
-	// When:
+	// When:.
 	cfg := AppFromContext(ctx)
 
-	// Then:
+	// Then:.
 	require.EqualValues(t, App{}, cfg)
 
-	// When:
+	// When:.
 	newCfg := App{Env: EnvDev}
 	ctx = context.WithValue(ctx, appCtxKey, newCfg)
 
-	// When:
+	// When:.
 	cfg = AppFromContext(ctx)
 
-	// Then:
+	// Then:.
 	require.EqualValues(t, newCfg, cfg)
 }
 
 func Test_SetAppInContext(t *testing.T) {
-	// Given:
+	// Given:.
 	ctx := context.Background()
 
-	// When:
+	// When:.
 	cfg := AppFromContext(ctx)
 
-	// Then:
+	// Then:.
 	require.EqualValues(t, App{}, cfg)
 
-	// When:
+	// When:.
 	newCfg := App{Env: EnvDev}
 	ctx = SetAppInContext(ctx, newCfg)
 
-	// When:
+	// When:.
 	require.EqualValues(t, newCfg, AppFromContext(ctx))
 }

--- a/src/golib/config/env.go
+++ b/src/golib/config/env.go
@@ -8,20 +8,20 @@ import (
 type Environment string
 
 const (
-	// EnvProd represents Prod env
+	// EnvProd represents Prod env.
 	EnvProd = Environment("production")
-	// EnvStaging represents Staging environment
+	// EnvStaging represents Staging environment.
 	EnvStaging = Environment("staging")
-	// EnvDev represents Development environment
+	// EnvDev represents Development environment.
 	EnvDev = Environment("development")
 )
 
-// String returns the string representation of the environment
+// String returns the string representation of the environment.
 func (e Environment) String() string {
 	return string(e)
 }
 
-// IsValid checks if the environment is valid or not
+// IsValid checks if the environment is valid or not.
 func (e Environment) IsValid() error {
 	if e != EnvDev && e != EnvStaging && e != EnvProd {
 		return fmt.Errorf("invalid env: [%s]", e)

--- a/src/golib/config/init_test.go
+++ b/src/golib/config/init_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestInit(t *testing.T) {
 	type testCase struct {
-		givenSentryEnabled                  bool
 		mockRes                             *resource.Resource
 		mockEnvStr                          string
 		mockResErr                          error
@@ -43,25 +42,25 @@ func TestInit(t *testing.T) {
 
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
-			// Given:
+			// Given:.
 			defer resetStubs()
 			var newOTELResourceFromEnvStubCalled bool
-			newOTELResourceFromEnvStub = func(ctx context.Context) (*resource.Resource, string, error) {
+			newOTELResourceFromEnvStub = func(context.Context) (*resource.Resource, string, error) {
 				newOTELResourceFromEnvStubCalled = true
 				return tc.mockRes, tc.mockEnvStr, tc.mockResErr
 			}
 
-			// When:
+			// When:.
 			ctx, err := Init()
 
-			// Then:
+			// Then:.
 			require.Equal(t, tc.expNewOTELResourceFromEnvStubCalled, newOTELResourceFromEnvStubCalled)
 
 			if tc.expErr != nil {
 				require.Equal(t, tc.expErr, err)
 				require.EqualValues(t, tc.expApp, AppFromContext(ctx))
 			} else {
-				require.Nil(t, err)
+				require.NoError(t, err)
 
 				app := AppFromContext(ctx)
 				require.EqualValues(t, tc.expApp, app)

--- a/src/golib/httpserver/server.go
+++ b/src/golib/httpserver/server.go
@@ -22,7 +22,7 @@ func NewServer(ctx context.Context, options ...ServerOption) (*Server, error) {
 			WriteTimeout: 10 * time.Second,
 			IdleTimeout:  120 * time.Second,
 			BaseContext: func(net.Listener) context.Context {
-				return ctx // TODO: Fix this
+				return ctx // TODO: Fix this.
 			},
 		},
 		gracefulShutdownTimeout: 10 * time.Second,
@@ -41,7 +41,7 @@ func NewServer(ctx context.Context, options ...ServerOption) (*Server, error) {
 	return s, nil
 }
 
-// Server is the server instance
+// Server is the server instance.
 type Server struct {
 	srv                     *http.Server
 	gracefulShutdownTimeout time.Duration
@@ -79,7 +79,8 @@ func (s *Server) stop(ctx context.Context) error {
 
 		telemetry.CaptureInfoEvent(ctx, "Attempting HTTP server force shutdown")
 		if err = s.srv.Close(); err != nil {
-			telemetry.CaptureErrorEvent(ctx, fmt.Errorf("httpserver:Server: force shutdown failed: %w", err))
+			err = fmt.Errorf("httpserver:Server: force shutdown failed: %w", err)
+			telemetry.CaptureErrorEvent(ctx, err)
 			return err
 		}
 	}
@@ -89,12 +90,12 @@ func (s *Server) stop(ctx context.Context) error {
 	return nil
 }
 
-// ServerOption customizes the Server
+// ServerOption customizes the Server.
 type ServerOption = func(srv *Server, m *chi.Mux) error
 
-// WithPort overrides the default server port with the given value
+// WithPort overrides the default server port with the given value.
 func WithPort(port int) ServerOption {
-	return func(s *Server, m *chi.Mux) error {
+	return func(s *Server, _ *chi.Mux) error {
 		if port <= 0 || port > 65535 {
 			return errors.New("invalid port number")
 		}
@@ -103,9 +104,9 @@ func WithPort(port int) ServerOption {
 	}
 }
 
-// WithReadTimeout overrides the default read timeout with the given value
+// WithReadTimeout overrides the default read timeout with the given value.
 func WithReadTimeout(d time.Duration) ServerOption {
-	return func(s *Server, m *chi.Mux) error {
+	return func(s *Server, _ *chi.Mux) error {
 		if d < 0 {
 			return errors.New("read timeout must be positive")
 		}
@@ -114,9 +115,9 @@ func WithReadTimeout(d time.Duration) ServerOption {
 	}
 }
 
-// WithWriteTimeout overrides the default write timeout with the given value
+// WithWriteTimeout overrides the default write timeout with the given value.
 func WithWriteTimeout(d time.Duration) ServerOption {
-	return func(s *Server, m *chi.Mux) error {
+	return func(s *Server, _ *chi.Mux) error {
 		if d < 0 {
 			return errors.New("write timeout must be positive")
 		}
@@ -125,9 +126,9 @@ func WithWriteTimeout(d time.Duration) ServerOption {
 	}
 }
 
-// WithIdleTimeout overrides the default idle timeout with the given value
+// WithIdleTimeout overrides the default idle timeout with the given value.
 func WithIdleTimeout(d time.Duration) ServerOption {
-	return func(s *Server, m *chi.Mux) error {
+	return func(s *Server, _ *chi.Mux) error {
 		if d < 0 {
 			return errors.New("idle timeout must be positive")
 		}
@@ -136,9 +137,9 @@ func WithIdleTimeout(d time.Duration) ServerOption {
 	}
 }
 
-// WithGracefulShutdownTimeout overrides the default graceful shutdown timeout with the given value
+// WithGracefulShutdownTimeout overrides the default graceful shutdown timeout with the given value.
 func WithGracefulShutdownTimeout(d time.Duration) ServerOption {
-	return func(s *Server, m *chi.Mux) error {
+	return func(s *Server, _ *chi.Mux) error {
 		if d < 0 {
 			return errors.New("graceful shutdown timeout must be positive")
 		}
@@ -147,10 +148,10 @@ func WithGracefulShutdownTimeout(d time.Duration) ServerOption {
 	}
 }
 
-// WithProfilingHandler enables go's pprof profiling
+// WithProfilingHandler enables go's pprof profiling.
 func WithProfilingHandler() ServerOption {
 	return func(_ *Server, m *chi.Mux) error {
-		// Based on https: //pkg.go.dev/net/http/pprof
+		// Based on https: //pkg.go.dev/net/http/pprof.
 		m.HandleFunc("/_/profile/*", pprof.Index)
 		m.HandleFunc("/_/profile/cmdline", pprof.Cmdline)
 		m.HandleFunc("/_/profile/profile", pprof.Profile)
@@ -166,7 +167,7 @@ func WithProfilingHandler() ServerOption {
 	}
 }
 
-// WithReadinessHandler sets the handler for readiness checks at `/_/ready`
+// WithReadinessHandler sets the handler for readiness checks at `/_/ready`.
 func WithReadinessHandler(h http.HandlerFunc) ServerOption {
 	return func(_ *Server, m *chi.Mux) error {
 		if h == nil {
@@ -177,7 +178,7 @@ func WithReadinessHandler(h http.HandlerFunc) ServerOption {
 	}
 }
 
-// WithRESTHandler sets the REST route handler
+// WithRESTHandler sets the REST route handler.
 func WithRESTHandler(rtr func(chi.Router)) ServerOption {
 	return func(_ *Server, m *chi.Mux) error {
 		if rtr == nil {
@@ -188,7 +189,7 @@ func WithRESTHandler(rtr func(chi.Router)) ServerOption {
 	}
 }
 
-// WithGQLHandler sets the GQL handler at `/graph` route
+// WithGQLHandler sets the GQL handler at `/graph` route.
 func WithGQLHandler(h http.Handler) ServerOption {
 	return func(_ *Server, m *chi.Mux) error {
 		if h == nil {
@@ -201,7 +202,7 @@ func WithGQLHandler(h http.Handler) ServerOption {
 
 func newRouter() *chi.Mux {
 	m := chi.NewRouter()
-	m.Get("/_/ping", func(w http.ResponseWriter, r *http.Request) {
+	m.Get("/_/ping", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		_, _ = fmt.Fprintln(w, "ok") // Intentionally ignoring the error as nothing to do once caught.

--- a/src/golib/httpserver/server_test.go
+++ b/src/golib/httpserver/server_test.go
@@ -15,28 +15,28 @@ import (
 )
 
 func TestNewServer(t *testing.T) {
-	// Given:
+	// Given:.
 	ctx := context.Background()
 
-	// When:
+	// When:.
 	s, err := NewServer(ctx)
 
-	// Then:
+	// Then:.
 	require.NoError(t, err)
 	require.NotNil(t, s)
 
-	// When:
+	// When:.
 	s, err = NewServer(ctx, func(_ *Server, _ *chi.Mux) error {
 		return errors.New("custom err")
 	})
 
-	// Then:
-	require.Error(t, errors.New("custom err"))
+	// Then:.
+	require.Error(t, err)
 	require.Nil(t, s)
 }
 
 func TestServer_Start(t *testing.T) {
-	// Given:
+	// Given:.
 	ctx := context.Background()
 
 	srv, err := NewServer(ctx)
@@ -48,13 +48,13 @@ func TestServer_Start(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	// When:
+	// When:.
 	go func() {
 		defer wg.Done()
 		err = srv.Start(ctx)
 	}()
 
-	// Then:
+	// Then:.
 	time.Sleep(2 * time.Second)
 	cancel()
 	wg.Wait()
@@ -62,99 +62,99 @@ func TestServer_Start(t *testing.T) {
 }
 
 func TestWithPort(t *testing.T) {
-	// Given:
+	// Given:.
 	s := &Server{srv: &http.Server{}}
 
-	// When:
+	// When:.
 	err := WithPort(-1)(s, nil)
 
-	// Then:
+	// Then:.
 	require.Equal(t, errors.New("invalid port number"), err)
 
-	// When:
+	// When:.
 	err = WithPort(3)(s, nil)
 	require.NoError(t, err)
 	require.Equal(t, ":3", s.srv.Addr)
 }
 
 func TestWithReadTimeout(t *testing.T) {
-	// Given:
+	// Given:.
 	s := &Server{srv: &http.Server{}}
 
-	// When:
+	// When:.
 	err := WithReadTimeout(-1)(s, nil)
 
-	// Then:
+	// Then:.
 	require.Equal(t, errors.New("read timeout must be positive"), err)
 
-	// When:
+	// When:.
 	err = WithReadTimeout(3)(s, nil)
 	require.NoError(t, err)
 	require.Equal(t, time.Duration(3), s.srv.ReadTimeout)
 }
 
 func TestWithWriteTimeout(t *testing.T) {
-	// Given:
+	// Given:.
 	s := &Server{srv: &http.Server{}}
 
-	// When:
+	// When:.
 	err := WithWriteTimeout(-1)(s, nil)
 
-	// Then:
+	// Then:.
 	require.Equal(t, errors.New("write timeout must be positive"), err)
 
-	// When:
+	// When:.
 	err = WithWriteTimeout(3)(s, nil)
 	require.NoError(t, err)
 	require.Equal(t, time.Duration(3), s.srv.WriteTimeout)
 }
 
 func TestWithIdleTimeout(t *testing.T) {
-	// Given:
+	// Given:.
 	s := &Server{srv: &http.Server{}}
 
-	// When:
+	// When:.
 	err := WithIdleTimeout(-1)(s, nil)
 
-	// Then:
+	// Then:.
 	require.Equal(t, errors.New("idle timeout must be positive"), err)
 
-	// When:
+	// When:.
 	err = WithIdleTimeout(3)(s, nil)
 	require.NoError(t, err)
 	require.Equal(t, time.Duration(3), s.srv.IdleTimeout)
 }
 
 func TestWithGracefulShutdownTimeout(t *testing.T) {
-	// Given:
+	// Given:.
 	s := &Server{srv: &http.Server{}}
 
-	// When:
+	// When:.
 	err := WithGracefulShutdownTimeout(-1)(s, nil)
 
-	// Then:
+	// Then:.
 	require.Equal(t, errors.New("graceful shutdown timeout must be positive"), err)
 
-	// When:
+	// When:.
 	err = WithGracefulShutdownTimeout(3)(s, nil)
 	require.NoError(t, err)
 	require.Equal(t, time.Duration(3), s.gracefulShutdownTimeout)
 }
 
 func TestWithProfilingHandler(t *testing.T) {
-	// Given:
+	// Given:.
 	m := chi.NewRouter()
 
-	// When:
+	// When:.
 	err := WithProfilingHandler()(nil, m)
 
-	// Then:
+	// Then:.
 	require.NoError(t, err)
 
 	var routesFound []string
 	require.NoError(t, chi.Walk(
 		m,
-		func(method string, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		func(method, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
 			routesFound = append(routesFound, method+" "+route)
 			return nil
 		},
@@ -178,23 +178,23 @@ func TestWithProfilingHandler(t *testing.T) {
 }
 
 func TestWithReadinessHandler(t *testing.T) {
-	// Given:
+	// Given:.
 	m := chi.NewRouter()
 
-	// When:
+	// When:.
 	err := WithReadinessHandler(nil)(nil, m)
 
-	// Then:
+	// Then:.
 	require.Equal(t, errors.New("readiness handler cannot be nil"), err)
 
-	// When:
+	// When:.
 	err = WithReadinessHandler(func(http.ResponseWriter, *http.Request) {})(nil, m)
 
-	// Then:
+	// Then:.
 	require.NoError(t, err)
 	require.NoError(t, chi.Walk(
 		m,
-		func(method string, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		func(method, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
 			require.Equal(t, "GET", method)
 			require.Equal(t, "/_/ready", route)
 			return nil
@@ -203,25 +203,25 @@ func TestWithReadinessHandler(t *testing.T) {
 }
 
 func TestWithRESTHandler(t *testing.T) {
-	// Given:
+	// Given:.
 	m := chi.NewRouter()
 
-	// When:
+	// When:.
 	err := WithRESTHandler(nil)(nil, m)
 
-	// Then:
+	// Then:.
 	require.Equal(t, errors.New("rest handler cannot be nil"), err)
 
-	// When:
+	// When:.
 	err = WithRESTHandler(func(rtr chi.Router) {
 		rtr.Get("/get", nil)
 	})(nil, m)
 
-	// Then:
+	// Then:.
 	require.NoError(t, err)
 	require.NoError(t, chi.Walk(
 		m,
-		func(method string, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		func(method, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
 			require.Equal(t, "GET", method)
 			require.Equal(t, "/get", route)
 			return nil
@@ -230,24 +230,24 @@ func TestWithRESTHandler(t *testing.T) {
 }
 
 func TestWithGQLHandler(t *testing.T) {
-	// Given:
+	// Given:.
 	m := chi.NewRouter()
 
-	// When:
+	// When:.
 	err := WithGQLHandler(nil)(nil, m)
 
-	// Then:
+	// Then:.
 	require.Equal(t, errors.New("gql handler cannot be nil"), err)
 
-	// When:
+	// When:.
 	err = WithGQLHandler(http.NewServeMux())(nil, m)
 
-	// Then:
+	// Then:.
 	require.NoError(t, err)
 	var routesFound []string
 	require.NoError(t, chi.Walk(
 		m,
-		func(method string, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		func(method, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
 			routesFound = append(routesFound, method+" "+route)
 			return nil
 		},
@@ -271,12 +271,12 @@ func TestWithGQLHandler(t *testing.T) {
 }
 
 func Test_newRouter(t *testing.T) {
-	// Given:
-	r := httptest.NewRequest("GET", "/_/ping", nil)
+	// Given:.
+	r := httptest.NewRequest(http.MethodGet, "/_/ping", nil)
 	w := httptest.NewRecorder()
 	m := newRouter()
 
-	// When:
+	// When:.
 	m.ServeHTTP(w, r)
 
 	require.Equal(t, http.StatusOK, w.Result().StatusCode)

--- a/src/golib/internal/basic/ctx.go
+++ b/src/golib/internal/basic/ctx.go
@@ -6,5 +6,5 @@ type ContextKey struct {
 	Name string
 }
 
-// String provides the string representation of ContextKey
+// String provides the string representation of ContextKey.
 func (k ContextKey) String() string { return "golib:context_key:" + k.Name }

--- a/src/golib/internal/cfg/otel_resource.go
+++ b/src/golib/internal/cfg/otel_resource.go
@@ -70,14 +70,14 @@ func loadServiceResourceFromEnv() ([]attribute.KeyValue, error) {
 	}
 
 	if v := getOTELEnvVar(semconv.ServiceNamespaceKey); v == "" {
-		// OTEL considers this optional, but we will consider it mandatory to avoid mistakes
+		// OTEL considers this optional, but we will consider it mandatory to avoid mistakes.
 		return nil, fmtMissingEnvVarError(semconv.ServiceNamespaceKey)
 	} else {
 		attrs = append(attrs, semconv.ServiceNamespace(v))
 	}
 
 	if v := getOTELEnvVar(semconv.ServiceVersionKey); v == "" {
-		// OTEL considers this optional, but we will consider it mandatory to avoid mistakes
+		// OTEL considers this optional, but we will consider it mandatory to avoid mistakes.
 		return nil, fmtMissingEnvVarError(semconv.ServiceVersionKey)
 	} else {
 		attrs = append(attrs, semconv.ServiceVersion(v))
@@ -109,7 +109,7 @@ func loadK8sResourceFromEnv() []attribute.KeyValue {
 		semconv.K8SCronJobName(getOTELEnvVar(semconv.K8SCronJobNameKey)),
 	}
 
-	intV, _ := strconv.Atoi(getOTELEnvVar(semconv.K8SContainerRestartCountKey)) // Intentionally suppressing the err since nothing to do
+	intV, _ := strconv.Atoi(getOTELEnvVar(semconv.K8SContainerRestartCountKey)) // Intentionally suppressing the err since nothing to do.
 	attrs = append(attrs, semconv.K8SContainerRestartCount(intV))
 
 	return attrs
@@ -129,11 +129,9 @@ func getOTELEnvVar(key attribute.Key) string {
 }
 
 func getOTELEnvVarKey(key attribute.Key) string {
-	// Convert key into OTEL_<envvar> format and replace dots with underscore
-	return fmt.Sprintf("OTEL_%s",
-		strings.ToUpper(
-			strings.Replace(string(key), ".", "_", -1),
-		),
+	// Convert key into OTEL_<envvar> format and replace dots with underscore.
+	return "OTEL_" + strings.ToUpper(
+		strings.ReplaceAll(string(key), ".", "_"),
 	)
 }
 

--- a/src/golib/internal/cfg/otel_resource_test.go
+++ b/src/golib/internal/cfg/otel_resource_test.go
@@ -3,7 +3,6 @@ package cfg
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -62,7 +61,7 @@ func TestNewOTELResourceFromEnv(t *testing.T) {
 				"OTEL_DEPLOYMENT_ENVIRONMENT": "development",
 				"OTEL_CONTAINER_NAME":         "container",
 				"OTEL_CONTAINER_IMAGE_NAME":   "gcr.io/opentelemetry/operator",
-				// "OTEL_CONTAINER_IMAGE_TAGS":   "tags", // TODO: Need to modify test case verification as the expected output is `[tags]` and I am too lazy to do it properly now
+				// "OTEL_CONTAINER_IMAGE_TAGS":   "tags", // TODO: Need to modify test case verification as the expected output is `[tags]` and I am too lazy to do it properly now.
 				"OTEL_CONTAINER_RUNTIME": "docker",
 			},
 			expEnv: "development",
@@ -75,7 +74,7 @@ func TestNewOTELResourceFromEnv(t *testing.T) {
 				"OTEL_DEPLOYMENT_ENVIRONMENT": "development",
 				"OTEL_CONTAINER_NAME":         "container",
 				"OTEL_CONTAINER_IMAGE_NAME":   "gcr.io/opentelemetry/operator",
-				// "OTEL_CONTAINER_IMAGE_TAGS":   "tags", // TODO: Need to modify test case verification as the expected output is `[tags]` and I am too lazy to do it properly now
+				// "OTEL_CONTAINER_IMAGE_TAGS":   "tags", // TODO: Need to modify test case verification as the expected output is `[tags]` and I am too lazy to do it properly now.
 				"OTEL_CONTAINER_RUNTIME":   "docker",
 				"OTEL_K8S_CLUSTER_NAME":    "cluster",
 				"OTEL_K8S_NODE_NAME":       "node",
@@ -98,7 +97,7 @@ func TestNewOTELResourceFromEnv(t *testing.T) {
 				"OTEL_DEPLOYMENT_ENVIRONMENT": "development",
 				"OTEL_CONTAINER_NAME":         "container",
 				"OTEL_CONTAINER_IMAGE_NAME":   "gcr.io/opentelemetry/operator",
-				// "OTEL_CONTAINER_IMAGE_TAGS":   "tags", // TODO: Need to modify test case verification as the expected output is `[tags]` and I am too lazy to do it properly now
+				// "OTEL_CONTAINER_IMAGE_TAGS":   "tags", // TODO: Need to modify test case verification as the expected output is `[tags]` and I am too lazy to do it properly now.
 				"OTEL_CONTAINER_RUNTIME":   "docker",
 				"OTEL_K8S_CLUSTER_NAME":    "cluster",
 				"OTEL_K8S_NODE_NAME":       "node",
@@ -112,7 +111,7 @@ func TestNewOTELResourceFromEnv(t *testing.T) {
 				"OTEL_K8S_CRONJOB_NAME":    "cron",
 				"OTEL_CLOUD_PROVIDER":      "heaven",
 				"OTEL_CLOUD_REGION":        "mountain",
-				// "OTEL_CLOUD_AVAILABILITY_ZONE": "downtown", // TODO: Need to modify test case verification as the key name is `cloud.availability_zone` instead of `cloud.availability.zone` and I am too lazy to do it properly now
+				// "OTEL_CLOUD_AVAILABILITY_ZONE": "downtown", // TODO: Need to modify test case verification as the key name is `cloud.availability_zone` instead of `cloud.availability.zone` and I am too lazy to do it properly now.
 				"OTEL_CLOUD_PLATFORM": "heaven-platform",
 			},
 			expEnv: "development",
@@ -121,12 +120,12 @@ func TestNewOTELResourceFromEnv(t *testing.T) {
 
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
-			// Given:
+			// Given:.
 			ctx := context.Background()
 			oldEnvVars := map[string]string{}
 			defer func() {
 				for k, v := range oldEnvVars {
-					require.NoError(t, os.Setenv(k, v))
+					t.Setenv(k, v)
 				}
 				withTelemetrySDKStub = resource.WithTelemetrySDK
 				withOSStub = resource.WithOS
@@ -136,7 +135,7 @@ func TestNewOTELResourceFromEnv(t *testing.T) {
 			}()
 			for k, v := range tc.givenEnvVars {
 				oldEnvVars[k] = os.Getenv(k)
-				require.NoError(t, os.Setenv(k, v))
+				t.Setenv(k, v)
 			}
 			var telStubCalled bool
 			withTelemetrySDKStub = func() resource.Option {
@@ -164,10 +163,10 @@ func TestNewOTELResourceFromEnv(t *testing.T) {
 				return resource.WithProcess()
 			}
 
-			// When:
+			// When:.
 			res, env, err := NewOTELResourceFromEnv(ctx)
 
-			// Then:
+			// Then:.
 			require.Equal(t, tc.expErr, err)
 			require.Equal(t, tc.expEnv, env)
 			if tc.expErr != nil {
@@ -199,6 +198,6 @@ func convertEnvVarToOTELKeyStr(key string) string {
 
 func cmpResAttrVal(t *testing.T, res *resource.Resource, key attribute.Key, expVal string) {
 	v, ok := res.Set().Value(key)
-	require.True(t, ok, fmt.Sprintf("missing: %s", string(key)))
-	require.Equal(t, expVal, v.Emit(), fmt.Sprintf("for: %s", string(key)))
+	require.True(t, ok, "missing: %s", string(key))
+	require.Equal(t, expVal, v.Emit(), "for: %s", string(key))
 }

--- a/src/golib/internal/melt/context_test.go
+++ b/src/golib/internal/melt/context_test.go
@@ -15,40 +15,40 @@ func TestContextKey_String(t *testing.T) {
 }
 
 func TestZapFromContext(t *testing.T) {
-	// Given:
+	// Given:.
 	ctx := context.Background()
 
-	// When:
+	// When:.
 	l := ZapFromContext(ctx)
 
-	// Then:
+	// Then:.
 	require.Nil(t, l)
 
-	// When:
+	// When:.
 	newL := zap.NewExample().Sugar()
 	ctx = context.WithValue(ctx, zapCtxKey, newL)
 
-	// When:
+	// When:.
 	l = ZapFromContext(ctx)
 
-	// Then:
+	// Then:.
 	require.EqualValues(t, newL, l)
 }
 
 func TestSetZapInContext(t *testing.T) {
-	// Given:
+	// Given:.
 	ctx := context.Background()
 
-	// When:
+	// When:.
 	l := ZapFromContext(ctx)
 
-	// Then:
+	// Then:.
 	require.Nil(t, l)
 
-	// When:
+	// When:.
 	newL := zap.NewExample().Sugar()
 	ctx = SetZapInContext(ctx, newL)
 
-	// When:
+	// When:.
 	require.EqualValues(t, newL, ZapFromContext(ctx))
 }

--- a/src/golib/internal/melt/otel_provider.go
+++ b/src/golib/internal/melt/otel_provider.go
@@ -1,6 +1,8 @@
 package melt
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutlog"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -9,7 +11,7 @@ import (
 func NewOTELLoggerProvider(res *resource.Resource) (*sdklog.LoggerProvider, error) {
 	logExporter, err := stdoutlog.New()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("err when creating stdoutlog exporter: %w", err)
 	}
 
 	loggerProvider := sdklog.NewLoggerProvider(

--- a/src/golib/internal/melt/otel_provider_test.go
+++ b/src/golib/internal/melt/otel_provider_test.go
@@ -11,17 +11,16 @@ import (
 )
 
 func TestNewOTELLoggerProvider(t *testing.T) {
-	// Given:
-	// Given:
+	// Given:.
 	res := resource.NewWithAttributes(
 		semconv.SchemaURL,
 		semconv.DeploymentEnvironment("development"),
 	)
 
-	// When:
+	// When:.
 	lp, err := NewOTELLoggerProvider(res)
 
-	// Then:
+	// Then:.
 	require.NoError(t, err)
 	require.NotNil(t, lp)
 	global.SetLoggerProvider(lp)

--- a/src/golib/internal/melt/zap.go
+++ b/src/golib/internal/melt/zap.go
@@ -13,7 +13,7 @@ func NewZap(debugMode bool, loggerProvider *sdklog.LoggerProvider) (*zap.Sugared
 	if debugMode {
 		z, err := zap.Config{
 			Level: zap.NewAtomicLevelAt(zapcore.DebugLevel),
-			// Development: true,
+			// Development: true,.
 			Encoding: "console",
 			EncoderConfig: zapcore.EncoderConfig{
 				TimeKey:        "T",

--- a/src/golib/internal/melt/zap_test.go
+++ b/src/golib/internal/melt/zap_test.go
@@ -10,27 +10,27 @@ import (
 )
 
 func Test_NewZap(t *testing.T) {
-	// Given:
+	// Given:.
 	res := resource.NewWithAttributes(
 		semconv.SchemaURL,
 		semconv.DeploymentEnvironment("development"),
 	)
 
-	// When:
+	// When:.
 	l, err := NewZap(true, nil)
 
-	// Then:
+	// Then:.
 	require.NoError(t, err)
 	require.NotNil(t, l)
 	l.Info("testing")
 
-	// When:
+	// When:.
 	lp, err := NewOTELLoggerProvider(res)
 	require.NoError(t, err)
 
 	l, err = NewZap(false, lp)
 
-	// Then:
+	// Then:.
 	require.NoError(t, err)
 	require.NotNil(t, l)
 	l.Info("testing")

--- a/src/golib/telemetry/attrs.go
+++ b/src/golib/telemetry/attrs.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kneadCODE/fursave/src/golib/internal/melt"
 )
 
-func WithAttrs(ctx context.Context, args ...interface{}) context.Context {
+func WithAttrs(ctx context.Context, args ...any) context.Context {
 	return melt.SetZapInContext(
 		ctx,
 		melt.ZapFromContext(ctx).With(args...),

--- a/src/golib/telemetry/attrs_test.go
+++ b/src/golib/telemetry/attrs_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestWithAttrs(t *testing.T) {
-	// Given:
+	// Given:.
 	ctx := context.Background()
 	res := resource.NewWithAttributes(semconv.SchemaURL, semconv.DeploymentEnvironment("development"))
 	lp, err := melt.NewOTELLoggerProvider(res)
@@ -20,7 +20,7 @@ func TestWithAttrs(t *testing.T) {
 	require.NoError(t, err)
 	ctx = melt.SetZapInContext(ctx, zapLogger)
 
-	// When:
+	// When:.
 	ctx = WithAttrs(ctx,
 		"string", "str",
 		"int", 1,
@@ -28,7 +28,7 @@ func TestWithAttrs(t *testing.T) {
 		"bool", true,
 	)
 
-	// Then:
+	// Then:.
 	CaptureInfoEvent(ctx, "test with attrs: %s", "hello world")
 	require.NoError(t, lp.ForceFlush(ctx))
 }

--- a/src/golib/telemetry/capture.go
+++ b/src/golib/telemetry/capture.go
@@ -6,32 +6,28 @@ import (
 	"github.com/kneadCODE/fursave/src/golib/internal/melt"
 )
 
-// CaptureDebugEvent captures the debug event and:-
-// - writes it to log
-func CaptureDebugEvent(ctx context.Context, msg string, args ...interface{}) {
+// - writes it to log.
+func CaptureDebugEvent(ctx context.Context, msg string, args ...any) {
 	if z := melt.ZapFromContext(ctx); z != nil {
 		z.Debugf(msg, args...)
 	}
 }
 
-// CaptureInfoEvent captures the informational event and:-
-// - writes it to log
-func CaptureInfoEvent(ctx context.Context, msg string, args ...interface{}) {
+// - writes it to log.
+func CaptureInfoEvent(ctx context.Context, msg string, args ...any) {
 	if z := melt.ZapFromContext(ctx); z != nil {
 		z.Infof(msg, args...)
 	}
 }
 
-// CaptureWarnEvent captures the warning event and:-
-// - writes it to log
-func CaptureWarnEvent(ctx context.Context, msg string, args ...interface{}) {
+// - writes it to log.
+func CaptureWarnEvent(ctx context.Context, msg string, args ...any) {
 	if z := melt.ZapFromContext(ctx); z != nil {
 		z.Warnf(msg, args...)
 	}
 }
 
-// CaptureErrorEvent captures the error event and:-
-// - writes it to log
+// - writes it to log.
 func CaptureErrorEvent(ctx context.Context, err error) {
 	if z := melt.ZapFromContext(ctx); z != nil {
 		z.Error(err)

--- a/src/golib/telemetry/capture_test.go
+++ b/src/golib/telemetry/capture_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 func TestCaptureDebugEvent(t *testing.T) {
-	// Given:
+	// Given:.
 	ctx := context.Background()
 
-	// When && Then:
+	// When && Then:.
 	CaptureDebugEvent(ctx, "some message")
 	CaptureDebugEvent(ctx, "some message: %s, %d, %f, %t", "s", 1, float32(32), true)
 	CaptureInfoEvent(ctx, "some message")
@@ -24,12 +24,12 @@ func TestCaptureDebugEvent(t *testing.T) {
 	CaptureWarnEvent(ctx, "some message: %s, %d, %f, %t", "s", 1, float32(32), true)
 	CaptureErrorEvent(ctx, errors.New("some err"))
 
-	// Given:
+	// Given:.
 	zapLogger, err := newZapStub(true, nil)
 	require.NoError(t, err)
 	ctx = melt.SetZapInContext(ctx, zapLogger)
 
-	// When && Then:
+	// When && Then:.
 	CaptureDebugEvent(ctx, "some message")
 	CaptureDebugEvent(ctx, "some message: %s, %d, %f, %t", "s", 1, float32(32), true)
 	CaptureInfoEvent(ctx, "some message")
@@ -38,7 +38,7 @@ func TestCaptureDebugEvent(t *testing.T) {
 	CaptureWarnEvent(ctx, "some message: %s, %d, %f, %t", "s", 1, float32(32), true)
 	CaptureErrorEvent(ctx, errors.New("some err"))
 
-	// Given:
+	// Given:.
 	res := resource.NewWithAttributes(semconv.SchemaURL, semconv.DeploymentEnvironment("development"))
 	lp, err := melt.NewOTELLoggerProvider(res)
 	require.NoError(t, err)
@@ -46,7 +46,7 @@ func TestCaptureDebugEvent(t *testing.T) {
 	require.NoError(t, err)
 	ctx = melt.SetZapInContext(ctx, zapLogger)
 
-	// When && Then:
+	// When && Then:.
 	CaptureDebugEvent(ctx, "some message")
 	CaptureDebugEvent(ctx, "some message: %s, %d, %f, %t", "s", 1, float32(32), true)
 	CaptureInfoEvent(ctx, "some message")

--- a/src/golib/telemetry/init.go
+++ b/src/golib/telemetry/init.go
@@ -13,10 +13,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// Init initializes the telemetry components and returns:-
-// - context with telemetry components stored within
-// - shutdown func to flush any pending telemetry items
-// - err if there was an error during initialization
+// - err if there was an error during initialization.
 func Init(ctx context.Context) (newCtx context.Context, shutdown func(), err error) {
 	basicLogger := log.New(os.Stdout, "", log.LstdFlags)
 	newCtx = ctx
@@ -60,7 +57,7 @@ func shutdownFunc(
 		go func() {
 			defer wg.Done()
 			basicLogger.Println("Shutting down zap...")
-			_ = zapLogger.Sync() // Intentionally ignoring err because we zap has a bug where it always returns err here
+			_ = zapLogger.Sync() // Intentionally ignoring err because we zap has a bug where it always returns err here.
 			basicLogger.Println("Zap shutdown complete. Now shuting down OTEL Logger provider...")
 			if err := otelLoggerP.Shutdown(cancelCtx); err != nil {
 				basicLogger.Printf("OTEL Logger provider shutdown failed: %s", err.Error())

--- a/src/golib/telemetry/init_test.go
+++ b/src/golib/telemetry/init_test.go
@@ -9,28 +9,28 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	// Given:
+	// Given:.
 	ctx := context.Background()
 	app := config.App{Env: config.EnvDev}
 	ctx = config.SetAppInContext(ctx, app)
 
-	// When:
+	// When:.
 	ctx, shutdown, err := Init(ctx)
 
-	// Then:
+	// Then:.
 	require.NoError(t, err)
 	require.NotNil(t, ctx)
 	CaptureInfoEvent(ctx, "some msg")
 	shutdown()
 
-	// Given:
+	// Given:.
 	app.Env = config.EnvProd
 	ctx = config.SetAppInContext(ctx, app)
 
-	// When:
+	// When:.
 	ctx, shutdown, err = Init(ctx)
 
-	// Then:
+	// Then:.
 	require.NoError(t, err)
 	require.NotNil(t, ctx)
 	CaptureInfoEvent(ctx, "some msg")

--- a/src/ledgersvc/.golangci.yaml
+++ b/src/ledgersvc/.golangci.yaml
@@ -1,0 +1,1 @@
+../../.golangci.yaml

--- a/src/ledgersvc/generate.go
+++ b/src/ledgersvc/generate.go
@@ -3,14 +3,13 @@
 package ledgersvc
 
 import (
-	// sqlboiler dependencies:-
-	_ "github.com/friendsofgo/errors"
-	_ "github.com/volatiletech/null/v8"
-	_ "github.com/volatiletech/sqlboiler/v4/boil"
-	_ "github.com/volatiletech/sqlboiler/v4/drivers"
-	_ "github.com/volatiletech/sqlboiler/v4/queries"
-	_ "github.com/volatiletech/sqlboiler/v4/queries/qm"
-	_ "github.com/volatiletech/sqlboiler/v4/queries/qmhelper"
-	_ "github.com/volatiletech/sqlboiler/v4/types"
-	_ "github.com/volatiletech/strmangle"
+	_ "github.com/friendsofgo/errors"                         // for sqlboiler.
+	_ "github.com/volatiletech/null/v8"                       // for sqlboiler.
+	_ "github.com/volatiletech/sqlboiler/v4/boil"             // for sqlboiler.
+	_ "github.com/volatiletech/sqlboiler/v4/drivers"          // for sqlboiler.
+	_ "github.com/volatiletech/sqlboiler/v4/queries"          // for sqlboiler.
+	_ "github.com/volatiletech/sqlboiler/v4/queries/qm"       // for sqlboiler.
+	_ "github.com/volatiletech/sqlboiler/v4/queries/qmhelper" // for sqlboiler.
+	_ "github.com/volatiletech/sqlboiler/v4/types"            // for sqlboiler.
+	_ "github.com/volatiletech/strmangle"                     // for sqlboiler.
 )


### PR DESCRIPTION
- **Implement golangci-lint as the Go linter**
- **Add golangci-lint to CI flow**

## Description
Add integration with golangci-lint for comprehensive static analysis and linting of Go code.

Implement golangci-lint as the Go linter
- Configure golangci-lint settings and linters
- Use common golangci-lint across all src via symlink
- Fix all reported golangci-lint issues

Also integrate it with GitHub Actions CI stage

## Related Issue

- Closes #31

