### PR TITLE
Setup ns TF module and ns deploy flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,13 @@ codacy-cov.sh
 src/**/pgorm/**/*
 src/**/build/binaries/
 
+# IDE
 .vscode
 .idea
+
+# Terraform
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+terraform.plan
+.terraform.lock.hcl

--- a/build/k8s/README.md
+++ b/build/k8s/README.md
@@ -1,0 +1,31 @@
+# Kubernetes Configuration Management
+
+This directory contains Kubernetes configurations divided into two main categories:
+
+## Directory Structure
+
+- `cluster-config/`: Cluster-level configurations
+  - Includes service mesh, OPA, ingress controller, etc.
+  - Managed with Kustomize across environments
+
+- `cluster-operations/`: App developer self-service configurations
+  - Namespace creation
+  - Network policies
+  - Shared operational configurations
+
+## Purpose
+
+This structure isolates:
+- Cluster-wide infrastructure configurations
+- Namespace and application-level operational configurations
+
+## Workflow
+
+1. Manage cluster-wide configurations in `cluster-config/`
+2. Create namespace and app-specific configurations in `cluster-operations/`
+
+## Best Practices
+
+- Keep cluster-level and app-level configurations separate
+- Use Kustomize for environment-specific customizations
+- Maintain clear separation of concerns

--- a/build/k8s/cluster-operations/README.md
+++ b/build/k8s/cluster-operations/README.md
@@ -1,0 +1,28 @@
+# Cluster Operations Configurations
+
+## Purpose
+
+This directory contains configurations for app developers to self-service their namespace and application-level configurations.
+
+## Supported Configurations
+
+- Namespace creation
+- Network policies
+- Resource quotas
+- Service accounts
+- Basic RBAC configurations
+
+## Usage Guidelines
+
+- Keep configurations minimal and focused
+- Follow least-privilege principle
+- Use templates for consistency
+- Avoid cluster-wide configurations (those belong in `cluster-config/`)
+
+## Recommended Workflow
+
+1. Create namespace configuration
+2. Define network policies
+3. Set up service accounts
+4. Configure resource quotas
+5. Apply RBAC rules as needed

--- a/build/k8s/cluster-operations/namespaces/dev/main.tf
+++ b/build/k8s/cluster-operations/namespaces/dev/main.tf
@@ -1,0 +1,5 @@
+module "ledgersvc" {
+  source = "../../../../../infra/tfmodules/k8s-namespace"
+
+  namespace_name = "ledgersvc"
+}

--- a/build/k8s/cluster-operations/namespaces/dev/providers.tf
+++ b/build/k8s/cluster-operations/namespaces/dev/providers.tf
@@ -1,0 +1,4 @@
+provider "kubernetes" {
+  config_path    = "~/.kube/config"
+  config_context = var.k8s_config_context
+}

--- a/build/k8s/cluster-operations/namespaces/dev/variables.tf
+++ b/build/k8s/cluster-operations/namespaces/dev/variables.tf
@@ -1,0 +1,4 @@
+variable "k8s_config_context" {
+  description = "Kubernetes config context to use"
+  type        = string
+}

--- a/build/k8s/cluster-operations/namespaces/dev/versions.tf
+++ b/build/k8s/cluster-operations/namespaces/dev/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.24.0"
+    }
+  }
+}

--- a/build/k8s/cluster-operations/namespaces/production/main.tf
+++ b/build/k8s/cluster-operations/namespaces/production/main.tf
@@ -1,0 +1,13 @@
+module "ledgersvc" {
+  source = "../../tfmodules/namespace"
+
+  namespace_name = "ledgersvc"
+
+  # resource_quotas = {
+  #   requests_cpu    = "8"
+  #   requests_memory = "16Gi"
+  #   limits_cpu      = "16"
+  #   limits_memory   = "32Gi"
+  #   max_pods        = 50
+  # }
+}

--- a/build/k8s/cluster-operations/namespaces/production/providers.tf
+++ b/build/k8s/cluster-operations/namespaces/production/providers.tf
@@ -1,0 +1,5 @@
+provider "kubernetes" {
+  # Configure your Kubernetes cluster access here
+  # For example:
+  # config_path = "~/.kube/config"
+}

--- a/build/k8s/cluster-operations/namespaces/production/versions.tf
+++ b/build/k8s/cluster-operations/namespaces/production/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.24.0"
+    }
+  }
+}

--- a/build/k8s/cluster-operations/namespaces/staging/main.tf
+++ b/build/k8s/cluster-operations/namespaces/staging/main.tf
@@ -1,0 +1,13 @@
+module "ledgersvc" {
+  source = "../../tfmodules/namespace"
+
+  namespace_name = "ledgersvc"
+
+  # resource_quotas = {
+  #   requests_cpu    = "4"
+  #   requests_memory = "8Gi"
+  #   limits_cpu      = "8"
+  #   limits_memory   = "16Gi"
+  #   max_pods        = 20
+  # }
+}

--- a/build/k8s/cluster-operations/namespaces/staging/providers.tf
+++ b/build/k8s/cluster-operations/namespaces/staging/providers.tf
@@ -1,0 +1,5 @@
+provider "kubernetes" {
+  # Configure your Kubernetes cluster access here
+  # For example:
+  # config_path = "~/.kube/config"
+}

--- a/build/k8s/cluster-operations/namespaces/staging/versions.tf
+++ b/build/k8s/cluster-operations/namespaces/staging/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.24.0"
+    }
+  }
+}

--- a/infra/tfmodules/k8s-namespace/locals.tf
+++ b/infra/tfmodules/k8s-namespace/locals.tf
@@ -1,0 +1,15 @@
+locals {
+  common_labels = {
+    "app.kubernetes.io/managed-by" = "terraform"
+    "app.kubernetes.io/part-of"    = var.namespace_name
+    "app.kubernetes.io/created-by" = "k8s-namespace-module"
+  }
+
+  role_labels = merge(local.common_labels, {
+    "app.kubernetes.io/component" = "rbac"
+  })
+
+  service_account_labels = merge(local.common_labels, {
+    "app.kubernetes.io/component" = "service-account"
+  })
+}

--- a/infra/tfmodules/k8s-namespace/main.tf
+++ b/infra/tfmodules/k8s-namespace/main.tf
@@ -1,0 +1,35 @@
+resource "kubernetes_namespace_v1" "this" {
+  metadata {
+    name = var.namespace_name
+    labels = merge(
+      local.common_labels,
+      {
+        "app.kubernetes.io/name"             = var.namespace_name
+        "pod-security.kubernetes.io/enforce" = var.pod_security_level
+        "pod-security.kubernetes.io/audit"   = var.pod_security_level
+        "pod-security.kubernetes.io/warn"    = var.pod_security_level
+      }
+    )
+  }
+}
+
+resource "kubernetes_resource_quota_v1" "this" {
+  metadata {
+    name      = "${var.namespace_name}-quota"
+    namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels = merge(local.common_labels, {
+      "app.kubernetes.io/name"      = "${var.namespace_name}-quota"
+      "app.kubernetes.io/component" = "resource-management"
+    })
+  }
+
+  spec {
+    hard = {
+      "requests.cpu"    = var.resource_quotas.requests_cpu
+      "requests.memory" = var.resource_quotas.requests_memory
+      "limits.cpu"      = var.resource_quotas.limits_cpu
+      "limits.memory"   = var.resource_quotas.limits_memory
+      "pods"            = var.resource_quotas.max_pods
+    }
+  }
+}

--- a/infra/tfmodules/k8s-namespace/outputs.tf
+++ b/infra/tfmodules/k8s-namespace/outputs.tf
@@ -1,0 +1,14 @@
+output "namespace_name" {
+  description = "Name of the created namespace"
+  value       = kubernetes_namespace_v1.this.metadata[0].name
+}
+
+output "namespace_uid" {
+  description = "UID of the created namespace"
+  value       = kubernetes_namespace_v1.this.metadata[0].uid
+}
+
+output "app_service_account_name" {
+  description = "Name of the app service account"
+  value       = kubernetes_service_account_v1.app.metadata[0].name
+}

--- a/infra/tfmodules/k8s-namespace/rbac.tf
+++ b/infra/tfmodules/k8s-namespace/rbac.tf
@@ -1,0 +1,111 @@
+
+
+resource "kubernetes_role_v1" "admin" {
+  metadata {
+    name      = "${kubernetes_namespace_v1.this.metadata[0].name}-admin-role"
+    namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels = merge(local.role_labels, {
+      "app.kubernetes.io/name" = "${kubernetes_namespace_v1.this.metadata[0].name}-admin-role"
+      "app.kubernetes.io/role" = "admin"
+    })
+  }
+
+  rule {
+    api_groups = ["*"]
+    resources  = ["*"]
+    verbs      = ["*"]
+  }
+}
+
+resource "kubernetes_role_v1" "readonly" {
+  metadata {
+    name      = "${kubernetes_namespace_v1.this.metadata[0].name}-readonly-role"
+    namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels = merge(local.role_labels, {
+      "app.kubernetes.io/name" = "${kubernetes_namespace_v1.this.metadata[0].name}-readonly-role"
+      "app.kubernetes.io/role" = "readonly"
+    })
+  }
+
+  rule {
+    api_groups = ["*"]
+    resources  = ["*"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["secrets"]
+    verbs      = ["get", "list"]
+  }
+}
+
+resource "kubernetes_role_v1" "app" {
+  metadata {
+    name      = "${kubernetes_namespace_v1.this.metadata[0].name}-app-role"
+    namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels = merge(local.role_labels, {
+      "app.kubernetes.io/name" = "${kubernetes_namespace_v1.this.metadata[0].name}-app-role"
+      "app.kubernetes.io/role" = "app"
+    })
+  }
+
+  rule {
+    api_groups = ["apps", "extensions"]
+    resources  = ["deployments", "statefulsets", "daemonsets"]
+    verbs      = ["get", "list", "create", "update", "patch", "delete"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods", "services", "configmaps", "persistentvolumeclaims"]
+    verbs      = ["get", "list", "create", "update", "patch", "delete"]
+  }
+
+  rule {
+    api_groups = ["networking.k8s.io"]
+    resources  = ["ingresses"]
+    verbs      = ["get", "list", "create", "update", "patch", "delete"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["secrets"]
+    verbs      = ["get", "list"]
+  }
+}
+
+resource "kubernetes_service_account_v1" "app" {
+  metadata {
+    name      = "${kubernetes_namespace_v1.this.metadata[0].name}-app-sa"
+    namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels = merge(local.service_account_labels, {
+      "app.kubernetes.io/name" = "${kubernetes_namespace_v1.this.metadata[0].name}-app-sa"
+      "app.kubernetes.io/role" = "app"
+    })
+  }
+}
+
+resource "kubernetes_role_binding_v1" "app" {
+  metadata {
+    name      = "${kubernetes_service_account_v1.app.metadata[0].name}-rb"
+    namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels = merge(local.common_labels, {
+      "app.kubernetes.io/name"      = "${kubernetes_service_account_v1.app.metadata[0].name}-rb"
+      "app.kubernetes.io/component" = "role-binding"
+      "app.kubernetes.io/role"      = "app"
+    })
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role_v1.admin.metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account_v1.app.metadata[0].name
+    namespace = kubernetes_namespace_v1.this.metadata[0].name
+  }
+}

--- a/infra/tfmodules/k8s-namespace/variables.tf
+++ b/infra/tfmodules/k8s-namespace/variables.tf
@@ -1,0 +1,26 @@
+variable "namespace_name" {
+  description = "Name of the Kubernetes namespace"
+  type        = string
+}
+
+variable "pod_security_level" {
+  description = "Pod Security Admission level"
+  type        = string
+  default     = "restricted"
+  validation {
+    condition     = contains(["privileged", "baseline", "restricted"], var.pod_security_level)
+    error_message = "Pod security level must be one of: privileged, baseline, restricted"
+  }
+}
+
+variable "resource_quotas" {
+  description = "Resource quotas for the namespace"
+  type = object({
+    requests_cpu    = optional(string, "1")
+    requests_memory = optional(string, "1Gi")
+    limits_cpu      = optional(string, "1")
+    limits_memory   = optional(string, "1Gi")
+    max_pods        = optional(number, 20)
+  })
+  default = {}
+}

--- a/infra/tfmodules/k8s-namespace/versions.tf
+++ b/infra/tfmodules/k8s-namespace/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.10.0"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.24.0"
+    }
+  }
+}


### PR DESCRIPTION
Setup ns TF module and ns deploy flow

## Why use Terraform?
Following the principle of least privilege, wanted to separate application configs and cluster level configs for k8s. But there is a middle ground where self-service cluster level operations would land, such as creating a namespace.

So, the solution was to create templates where the cluster operators define how the ns would be created along with the resource quota, rbac, etc., resulting in standardized templates for governance. Then these templates would be used by the app teams to setup the actual ns.

To solve this, as far as I found there are only 3 different solutions: kustomize, helm, terraform:-
1. kustomize: Solution works but looks unnecessarily complicated and nested.
2. helm: Solution didn't work because helm needs a ns to be present first or ask it to create ns as a flag rather than the mainifest. Simply put, helm was not designed for our needs as specified above.
3. terraform: Solution works best, but requires state management.

Ultimately decided to go with terraform since in Staging & Production we will actually have proper state management and for dev just use local state but the state is pointless since we can just recreate the cluster from scratch.